### PR TITLE
fix some more broken self-closed tags

### DIFF
--- a/domtemplate.php
+++ b/domtemplate.php
@@ -397,7 +397,7 @@ abstract class DOMTemplateNode {
 		$source = preg_replace ('/<([^<]*[^ ])\/>/', '<$1 />', $source);
 		//fix broken self-closed tags; e.g. `<script ...></script>` will automatically be converted to
 		//`<script ... />` on loading the document, this breaks in browsers so we have to fix it on output
-		$source = preg_replace ('/<(div|iframe|[ou]l|script|textarea|title)([^>]*) ?\/>/i', '<$1$2></$1>', $source);
+		$source = preg_replace ('/<(del|div|h[1-6]|iframe|[ou]l|option|script|span|td|textarea|title)([^>]*) ?\/>/i', '<$1$2></$1>', $source);
 		//convert XML style attributes (`<a attr="attr">`) to HTML style attributes (`<a attr>`),
 		//this needs to be repeated until none are left as we must anchor each to the opening bracket of
 		//the element, otherwise content text might be hit too


### PR DESCRIPTION
prevent browser-DOM from breaking on empty DOM elements (like `<h1></h1>`, etc.)